### PR TITLE
Update reprostim to 0.7.27

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "reprostim" %}
-{% set version = "0.7.25" %}
+{% set version = "0.7.27" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/reprostim-{{ version }}.tar.gz
-  sha256: b18c08c4da897b8201a815805aacc45287086995deec07d7c218b0a87fb4af65
+  sha256: d54ba66ce15bc61bdab9309f438085c81133a27c7532195ed1fc75e1ad540b4b
 
 build:
   noarch: python
@@ -32,6 +32,8 @@ requirements:
     - qrcode >=8.0
     - opencv >=4.9.0
     - pyzbar =0.1.8
+    - filelock >=3.16.0
+    - isodate >=0.7.2
 
 test:
   imports:
@@ -44,6 +46,7 @@ test:
     - pytest-cov
     - reedsolo >=1.7.0
     - scipy
+    - pytest-mock
   source_files:
     - tests
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
**Changes**

  - Bump version from 0.7.25 to 0.7.27
  - Update source sha256 to match 0.7.27 tarball
  - Add missing runtime dependencies `filelock >=3.16.0` and `isodate >=0.7.2`
    (added in 0.7.26 to pyproject.toml but missing from recipe, causing CI test failures)
  - Add `pytest-mock` to test requirements

  Fixes conda-forge CI failures for 0.7.26 and 0.7.27.
